### PR TITLE
Includes attribute target='_blank' on href with reference to external…

### DIFF
--- a/DominicanWhoCodes.Blazor/Shared/CardComponent.razor
+++ b/DominicanWhoCodes.Blazor/Shared/CardComponent.razor
@@ -22,10 +22,10 @@
             </p>
         </div>
         <div class="social-networks">
-            @if(Webpage != null) { <a href="@Webpage" class="text-dark"><i class="fas fa-globe-americas"></i></a> }
-            @if(LinkedIn != null) { <a href="@LinkedIn" class="text-dark"><i class="fab fa-linkedin"></i></a> }
-            @if(Twitter != null) { <a href="@Twitter" class="text-dark"><i class="fab fa-twitter"></i></a> }
-            @if(Github != null) { <a href="@Github" class="text-dark"><i class="fab fa-github"></i></a> }
+            @if(Webpage != null) { <a href="@Webpage" target="_blank" class="text-dark"><i class="fas fa-globe-americas"></i></a> }
+            @if(LinkedIn != null) { <a href="@LinkedIn" target="_blank" class="text-dark"><i class="fab fa-linkedin"></i></a> }
+            @if(Twitter != null) { <a href="@Twitter" target="_blank" class="text-dark"><i class="fab fa-twitter"></i></a> }
+            @if(Github != null) { <a href="@Github" target="_blank" class="text-dark"><i class="fab fa-github"></i></a> }
         </div>
     </div>
 </div>


### PR DESCRIPTION
This modifies CardComponent to include target="_blank" on href used within profile. It will help users to keep looking different profiles on DominicanWhoCodes and at the same time continue exploring more information on sites like LinkedIn, Twitter and so on. 

Steps to test it.

Click on different links on profile components. 

- Website Link
- LinkedIn Profile Link
- Github Profile Link
- Twitter Profile Link

They should all open on different tabs on the browser. 