### PR TITLE
Use correct NotEqual overload

### DIFF
--- a/DWC.Blazor.Tests/ShuffleAlgorithmTests.cs
+++ b/DWC.Blazor.Tests/ShuffleAlgorithmTests.cs
@@ -45,7 +45,7 @@ namespace DWC.Blazor.Tests
             var result = source.Shuffle().ToList();
 
             // Assert
-            Assert.NotEqual<IEnumerable<int>>(source, result);
+            Assert.NotEqual<int>(source, result);
         }
     }
 }


### PR DESCRIPTION
This test was using the incorrect overload of Assert.NotEqual.

`Assert.NotEqual<IEnumerable<int>>(source, result)` is comparing the instance of two objects.

But `Assert.NotEqual<int>(source, result)` is comparing the sequence of the items in both lists.