### PR TITLE
Improve Shuffle extension method

### DIFF
--- a/DWC.Blazor/Extensions/LinqExtensions.cs
+++ b/DWC.Blazor/Extensions/LinqExtensions.cs
@@ -37,10 +37,7 @@ namespace DWC.Blazor.Extensions
                 array[j] = buffer;
             }
 
-            for (int i = 0; i < length; i++)
-            {
-                yield return array[i];
-            }
+            return array;
         }
     }
 }


### PR DESCRIPTION
There is no need to use yield return in this method since the entire array is already in memory.