### PR TITLE
Code scanning: CodeQL Action v1 is now deprecated

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
### General

[Blog](https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/#how-does-this-affect-me)

On March 30, 2022, we released CodeQL Action v2, which runs on the Node.js 16 runtime. In April 2022, we announced that CodeQL Action v1 would be deprecated at the same time as GitHub Enterprise Server (GHES) 3.3.
This deprecation period has elapsed and starting January 18, 2023, CodeQL Action v1 is now discontinued.
It will no longer be updated or supported, and while we will not be deleting it except in the case of a security vulnerability, workflows using it may eventually break.
New CodeQL analysis capabilities will only be available to users of v2.

### Type

- [x] Fix

### Describe the changes here (summarized)

To upgrade to the CodeQL Action v2, open your CodeQL workflow file(s) in the .github/workflows directory of your repository and look for references to:

- github/codeql-action/init@v1
- github/codeql-action/autobuild@v1
- github/codeql-action/analyze@v1
- github/codeql-action/upload-sarif@v1

These entries need to be replaced with their v2 equivalents:

- github/codeql-action/init@v2
- github/codeql-action/autobuild@v2
- github/codeql-action/analyze@v2
- github/codeql-action/upload-sarif@v2