### PR TITLE
fix: upgrade .NET SDK version in Azure Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-  dotnetVersion: '8.0.119'
+  dotnetVersion: '8.0.x'
 
 steps:
 - task: UseDotNet@2


### PR DESCRIPTION
## Problem
Azure Pipeline is failing when Dependabot updates `Microsoft.NET.ILLink.Tasks` to version 8.0.20 because the hosted agent only has .NET 8.0.19 installed.

## Solution
Changed `dotnetVersion` from `'8.0.119'` to `'8.0.x'` to automatically use the latest patch version available on the hosted agent.

## Benefits
- Resolves compatibility issues with newer NuGet packages
- Prevents future version mismatch errors
- Allows Dependabot PR #382 to pass CI checks

## Testing
- [x] Pipeline runs successfully with .NET 8.0.x
- [x] Compatible with Microsoft.NET.ILLink.Tasks 8.0.20

Fixes #382