### PR TITLE
Bump Microsoft.NET.ILLink.Tasks from 8.0.23 to compatible 8.x versions

### DIFF
--- a/DWC.Blazor/DWC.Blazor.csproj
+++ b/DWC.Blazor/DWC.Blazor.csproj
@@ -17,7 +17,7 @@
 
     <PackageReference Include="Microsoft.NET.ILLink.Analyzers" Version="7.0.100-1.23401.1" />
 
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.23" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.7" />
     <Content Update="wwwroot\data\developers.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/DWC.Blazor/DWC.Blazor.csproj
+++ b/DWC.Blazor/DWC.Blazor.csproj
@@ -15,9 +15,9 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.NET.ILLink.Analyzers" Version="7.0.100-1.23401.1" />
+    <PackageReference Include="Microsoft.NET.ILLink.Analyzers" Version="8.0.100-1.23067.1" />
 
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.26" />
     <Content Update="wwwroot\data\developers.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
- Updated Microsoft.NET.ILLink.Tasks to 8.0.26 (compatible with net8.0).
- Updated Microsoft.NET.ILLink.Analyzers to 8.0.100-1.23067.1 for net8.0 compatibility.
- Verified build and tests pass with these versions.